### PR TITLE
FEATURE/ignore-executive-sessions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ cdptools
 .. image:: https://img.shields.io/pypi/v/cdptools.svg
         :target: https://pypi.python.org/pypi/cdptools
 
-.. image:: https://img.shields.io/travis/JacksonMaxfield/cdptools.svg
-        :target: https://travis-ci.org/JacksonMaxfield/cdptools
+.. image:: https://img.shields.io/travis/CouncilDataProject/cdptools.svg
+        :target: https://travis-ci.org/CouncilDataProject/cdptools
 
 .. image:: https://readthedocs.org/projects/cdptools/badge/?version=latest
         :target: https://cdptools.readthedocs.io/en/latest/?badge=latest
@@ -26,17 +26,6 @@ Features
 --------
 
 * TODO
-
-
-Notes on Hitting Exposed Database Endpoints
--------------------------------------------
-`pip install git+https://github.com/ozgur/python-firebase.git`
-
-```
-from firebase import firebase
-firebase = firebase.FirebaseApplication("https://your-cdp-target.firebaseio.com/")
-events = firebase.get("/events", None)
-```
 
 
 Credits

--- a/cdptools/event_scrapers/seattle_event_scraper.py
+++ b/cdptools/event_scrapers/seattle_event_scraper.py
@@ -162,6 +162,10 @@ class SeattleEventScraper(EventScraper):
             except AttributeError:
                 raise errors.EventParseError(body, dt)
 
+        # Check executive session
+        if "executive session" in agenda.lower():
+            raise errors.ExecutiveSessionError(body, dt)
+
         # The agenda is returned as a single string
         # Clean it and split it into its parts
         agenda = agenda.replace("Agenda:", "")
@@ -229,7 +233,7 @@ class SeattleEventScraper(EventScraper):
                 # Successful parse
                 events.success.append(event)
 
-            except errors.EventOutOfTimeboundsError as e:
+            except (errors.EventOutOfTimeboundsError, errors.ExecutiveSessionError) as e:
                 # For logging purposes, return the errors
                 events.warning.append((container, e))
 

--- a/cdptools/pipelines/event_pipeline.py
+++ b/cdptools/pipelines/event_pipeline.py
@@ -74,6 +74,7 @@ class EventPipeline(Pipeline):
                     key=key,
                     save_name="video.mp4"
                 )
+                log.info(f"Stored video at: {local_video_path}")
 
                 # Create audio split of video
                 # temp_audio_path = self.audio_splitters.split(local_paths["video"])


### PR DESCRIPTION
Executive sessions are closed to the public but roughly four minute videos of the beginning of the meetings exist on Seattle Channel. This adds a small check to ignore them.