### PR TITLE
FEATURE/create-time-stamped-transcript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr .tox/
 	rm -f .coverage
 	rm -fr htmlcov/
-	rm coverage.xml
+	rm -f coverage.xml
 	rm -fr .pytest_cache
 
 lint: ## check style with flake8

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ cdptools
 .. image:: https://img.shields.io/pypi/v/cdptools.svg
         :target: https://pypi.python.org/pypi/cdptools
 
-.. image:: https://img.shields.io/travis/CouncilDataProject/cdptools.svg
+.. image:: https://img.shields.io/travis/CouncilDataProject/cdptools.svg?branch=master
         :target: https://travis-ci.org/CouncilDataProject/cdptools
 
 .. image:: https://codecov.io/gh/CouncilDataProject/cdptools/branch/master/graph/badge.svg
@@ -24,10 +24,10 @@ Quickstart Documentation
 
 Please view the examples_ directory for example jupyter notebooks on how to use CDP databases and file stores.
 
-For additional information on system design, look at docs/system_design.md_.
+For additional information on system design, look at system_design.md_.
 
 .. _examples: https://github.com/CouncilDataProject/cdptools/tree/master/examples
-.. _docs/system_design.md: https://github.com/CouncilDataProject/cdptools/blob/master/docs/system_design.md
+.. _system_design.md: https://github.com/CouncilDataProject/cdptools/blob/master/docs/system_design.md
 
 
 Credits

--- a/cdptools/pipelines/event_pipeline.py
+++ b/cdptools/pipelines/event_pipeline.py
@@ -163,7 +163,7 @@ class EventPipeline(Pipeline):
             # Check event already exists in database
             found_event = self.database.get_event(event["video_uri"])
             if found_event:
-                log.info("Skipping event: {} ({})".format(key, found_event["id"]))
+                log.info("Skipping event: {} ({})".format(key, found_event["event_id"]))
             else:
                 log.info("Processing event: {} ({})".format(key, event["video_uri"]))
 
@@ -179,7 +179,7 @@ class EventPipeline(Pipeline):
 
                 # Store event
                 event_details = self.database.get_or_upload_event(
-                    body_id=body_details["id"],
+                    body_id=body_details["body_id"],
                     event_datetime=event["event_datetime"],
                     source_uri=event["source_uri"],
                     video_uri=event["video_uri"]
@@ -187,12 +187,12 @@ class EventPipeline(Pipeline):
 
                 # Link event to transcript
                 self.database.get_or_upload_transcript(
-                    event_id=event_details["id"],
-                    file_id=transcript_file_details["id"],
+                    event_id=event_details["event_id"],
+                    file_id=transcript_file_details["file_id"],
                     confidence=confidence
                 )
 
-                log.info("Uploaded event details: {} ({})".format(event_details["id"], key))
+                log.info("Uploaded event details: {} ({})".format(event_details["event_id"], key))
 
             # Update progress
             log.info("Completed event: {} ({})".format(key, event["video_uri"]))

--- a/cdptools/sr_models/google_cloud_sr_model.py
+++ b/cdptools/sr_models/google_cloud_sr_model.py
@@ -4,11 +4,11 @@
 import json
 import logging
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Union
 
 from google.cloud import speech_v1p1beta1 as speech
 
-from .sr_model import SRModel
+from .sr_model import SRModel, SRModelOutputs
 
 ###############################################################################
 
@@ -27,11 +27,18 @@ class GoogleCloudSRModel(SRModel):
         # Resolve credentials
         self.credentials_path = Path(credentials_path).resolve(strict=True)
 
-    def transcribe(self, audio_uri: str, transcript_save_path: Union[str, Path]) -> Tuple[Path, float]:
-        # Check path
-        transcript_save_path = Path(transcript_save_path).resolve()
-        if transcript_save_path.is_file():
-            return transcript_save_path
+    def transcribe(
+        self,
+        audio_uri: Union[str, Path],
+        raw_transcript_save_path: Union[str, Path],
+        timestamped_words_save_path: Union[str, Path],
+        timestamped_sentences_save_path: Union[str, Path],
+        **kwargs
+    ) -> SRModelOutputs:
+        # Check paths
+        raw_transcript_save_path = Path(raw_transcript_save_path).resolve()
+        timestamped_words_save_path = Path(timestamped_words_save_path).resolve()
+        timestamped_sentences_save_path = Path(timestamped_sentences_save_path).resolve()
 
         # Create client
         client = speech.SpeechClient.from_service_account_json(self.credentials_path)
@@ -54,41 +61,62 @@ class GoogleCloudSRModel(SRModel):
         response = operation.result(timeout=4000)
 
         # Select highest confidence transcripts
-        full_transcript = None
         confidence_sum = 0
         segments = 0
-        timestamped_transcript = {}
+        timestamped_words = {}
         for result in response.results:
             # Some portions of audio may not have text
             if len(result.alternatives) > 0:
                 # Check length of transcript result
-                transcript_result = result.alternatives[0].transcript
-                word_details = result.alternatives[0].words
-                if len(word_details) > 0:
-                    start_time = word_details[0].start_time.seconds + word_details[0].start_time.nanos * 1e-9
-                    timestamped_transcript[start_time] = " ".join([wd.word for wd in word_details])
-                if len(transcript_result) > 0:
-                    # Initial start
-                    if full_transcript:
-                        full_transcript = f"{full_transcript} {transcript_result}"
-                    else:
-                        full_transcript = transcript_result
+                word_list = result.alternatives[0].words
+                if len(word_list) > 0:
+                    for word in word_list:
+                        start_time = word.start_time.seconds + word.start_time.nanos * 1e-9
+                        timestamped_words[start_time] = word.word
 
                     # Update confidence stats
                     confidence_sum += result.alternatives[0].confidence
                     segments += 1
 
-        with open("timestamped_transcript.json", "w") as write_out:
-            json.dump(timestamped_transcript, write_out)
+        # Create timestamped sentences
+        timestamped_sentences = {}
+        current_start_time = None
+        for start_time, word in timestamped_words.items():
+            # Update current start time
+            if current_start_time is None:
+                current_start_time = start_time
+
+            # Create or update sentence
+            if current_start_time in timestamped_sentences:
+                timestamped_sentences[current_start_time] += f" {word}"
+            else:
+                timestamped_sentences[current_start_time] = word
+
+            # Reset current start time if sentence end
+            if word[-1] == ".":
+                current_start_time = None
+
+        # Create raw transcript
+        raw_transcript = " ".join(timestamped_words.values())
 
         # Compute mean confidence
         confidence = confidence_sum / segments
-        log.info(f"Completed transcription for: {audio_uri}")
+        log.info(f"Completed transcription for: {audio_uri}. Confidence: {confidence}")
 
-        # Store transcript
-        with open(transcript_save_path, "w") as write_out:
-            write_out.write(full_transcript)
-        log.debug(f"Stored transcript at: {transcript_save_path}")
+        # Write files
+        with open(timestamped_words_save_path, "w") as write_out:
+            json.dump(timestamped_words, write_out)
+
+        with open(timestamped_sentences_save_path, "w") as write_out:
+            json.dump(timestamped_sentences, write_out)
+
+        with open(raw_transcript_save_path, "w") as write_out:
+            write_out.write(raw_transcript)
 
         # Return the save path
-        return transcript_save_path, confidence
+        return SRModelOutputs(
+            raw_transcript_save_path,
+            confidence,
+            timestamped_words_save_path,
+            timestamped_sentences_save_path
+        )

--- a/cdptools/sr_models/sr_model.py
+++ b/cdptools/sr_models/sr_model.py
@@ -3,17 +3,37 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Any, Dict, NamedTuple, Optional, Union
 
 ###############################################################################
+
+
+class SRModelOutputs(NamedTuple):
+    raw_path: Path
+    confidence: float
+    timestamped_words_path: Optional[Path] = None
+    timestamped_sentences_path: Optional[Path] = None
+    extras: Optional[Dict[str, Any]] = None
 
 
 class SRModel(ABC):
 
     @abstractmethod
-    def transcribe(self, audio_uri: Union[str, Path], transcript_save_path: Union[str, Path]) -> Tuple[Path, float]:
+    def transcribe(
+        self,
+        audio_uri: Union[str, Path],
+        raw_transcript_save_path: Union[str, Path],
+        timestamped_words_save_path: Optional[Union[str, Path]] = None,
+        timestamped_sentences_save_path: Optional[Union[str, Path]] = None,
+        **kwargs
+    ) -> SRModelOutputs:
         """
         Transcribe audio from file and store in text file.
         """
 
-        return Path("/root/.local/path/to/file/id.txt")
+        return SRModelOutputs(
+            Path(raw_transcript_save_path),
+            1.0,
+            timestamped_words_save_path,
+            timestamped_sentences_save_path
+        )

--- a/cdptools/utils/run_manager.py
+++ b/cdptools/utils/run_manager.py
@@ -170,7 +170,7 @@ class RunManager():
         # Handle exception
         if exception_type:
             # Write traceback to file
-            traceback_path = Path(f"exception_log_{str(uuid4())}.log")
+            traceback_path = Path(f"exception_log_{str(uuid4())}.err")
             with open(traceback_path, "w") as exception_log:
                 exception_log.write(traceback.format_exc())
 

--- a/cdptools/utils/run_manager.py
+++ b/cdptools/utils/run_manager.py
@@ -145,21 +145,21 @@ class RunManager():
         )
 
         # Create run
-        run_details = self._db.get_or_upload_run(algorithm_details["id"], self._began, self._completed)
+        run_details = self._db.get_or_upload_run(algorithm_details["algorithm_id"], self._began, self._completed)
         log.debug(f"Created run: {run_details}")
 
         # Create file inputs and outputs in db
         for fi in input_files:
-            self._db.get_or_upload_run_input_file(run_details["id"], fi["id"])
+            self._db.get_or_upload_run_input_file(run_details["run_id"], fi["file_id"])
         for fo in output_files:
-            self._db.get_or_upload_run_output_file(run_details["id"], fo["id"])
+            self._db.get_or_upload_run_output_file(run_details["run_id"], fo["file_id"])
         log.debug("Linked run to I/O files")
 
         # Create other inputs and outputs in db
         for i in self._inputs:
-            self._db.get_or_upload_run_input(run_details["id"], i.type, i.value)
+            self._db.get_or_upload_run_input(run_details["run_id"], i.type, i.value)
         for o in self._outputs:
-            self._db.get_or_upload_run_output(run_details["id"], o.type, o.value)
+            self._db.get_or_upload_run_output(run_details["run_id"], o.type, o.value)
         log.debug("Linked run to I/O values")
 
     def __enter__(self):

--- a/configs/event_pipeline.json
+++ b/configs/event_pipeline.json
@@ -30,5 +30,17 @@
         "object_kwargs": {
             "credentials_path": "/home/cdptools/credentials/cdp_seattle_cloud_platform_all.json"
         }
-    }
+    },
+    "mocks": [
+        {
+            "path": "cdptools.event_scrapers.seattle_event_scraper.SeattleEventScraper.get_events",
+            "return_value": [{
+                "agenda_items": ["Public Comment", "CB 999999"],
+                "body": "Example Body on Tests",
+                "event_datetime": "2019-05-05T00:00:00",
+                "source_uri": "http://www.seattlechannel.org/testing?videoid=x99999",
+                "video_uri": "http://video.seattle.gov:8080/media/council/council_041119_2021928V.mp4"
+            }]
+        }
+    ]
 }

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     entry_points={
         'console_scripts': [
             'run_cdp_pipeline=cdptools.bin.run_cdp_pipeline:main',
+            'test_cdp_pipeline=cdptools.bin.test_cdp_pipeline:main',
         ],
     },
     install_requires=requirements,


### PR DESCRIPTION
Resolves [gh-32], transcripts come in three variants, raw, timestamped words, and timestamped sentences. The variant chosen as "the" transcript for an event is determined in the same order above, with timestamped sentences having highest priority and raw having least priority.

Fixes the downstream effects caused but not fixed by [gh-31].

Finally, adds a `test_cdp_pipeline` bin script that can be used with a list of mocks to test the entire pipeline instead of simply just the modules of the pipeline.