### PR TITLE
bugfix/update-bin-to-use-new-load-custom-object

### DIFF
--- a/cdptools/__init__.py
+++ b/cdptools/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = "Jackson Maxfield Brown"
 __email__ = "jmaxfieldbrown@gmail.com"
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 from .cdp_instance import CDPInstance  # noqa: F401
 

--- a/cdptools/bin/run_cdp_pipeline.py
+++ b/cdptools/bin/run_cdp_pipeline.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 import schedule
 
-from cdptools import get_module_version, pipelines
+from cdptools import get_module_version
+from cdptools.dev_utils import load_custom_object
 
 ###############################################################################
 
@@ -46,7 +47,7 @@ class Args(argparse.Namespace):
 def run_cdp_pipeline(args: Args):
     try:
         # Initialize pipeline
-        pipeline = pipelines.Pipeline.load_custom_object(
+        pipeline = load_custom_object.load_custom_object(
             module_path="cdptools.pipelines",
             object_name=args.pipeline_type,
             object_kwargs={"config_path": args.config_path}

--- a/deploy/event_gather_vm_setup.sh
+++ b/deploy/event_gather_vm_setup.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+apt-get update
+apt-get install software-properties-common -y
+apt-get install ffmpeg -y
+apt-get install python3-pip -y

--- a/deploy/event_index_vm_setup.sh
+++ b/deploy/event_index_vm_setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+apt-get update
+apt-get install software-properties-common -y
+apt-get install python3-pip -y

--- a/deploy/minutes_item_index_vm_setup.sh
+++ b/deploy/minutes_item_index_vm_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+apt-get update
+apt-get install software-properties-common -y
+apt-get install default-jdk -y
+apt-get install python3-pip -y
+export JAVA_HOME="/usr/bin/java"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.1
+current_version = 2.0.2
 commit = True
 tag = True
 
@@ -23,3 +23,4 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
+

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,6 @@ setup(
     tests_require=test_requirements,
     extras_require=extra_requirements,
     url="https://github.com/CouncilDataProject/cdptools",
-    version="2.0.1",
+    version="2.0.2",
     zip_safe=False,
 )


### PR DESCRIPTION
Fixes `run_cdp_pipeline` due to changed how `load_custom_object` is referenced.

Additionally adds some bash scripts to setup vms for various pipelines.