### PR TITLE
feature/update-database-schema

### DIFF
--- a/cdptools/databases/cloud_firestore_database.py
+++ b/cdptools/databases/cloud_firestore_database.py
@@ -467,7 +467,8 @@ class CloudFirestoreDatabase(Database):
     def get_or_upload_minutes_item(
         self,
         name: str,
-        matter: Optional[str],
+        matter: Optional[str] = None,
+        title: Optional[str] = None,
         legistar_event_item_id: Optional[int] = None
     ) -> Dict:
         return self._get_or_upload_row(
@@ -476,6 +477,7 @@ class CloudFirestoreDatabase(Database):
             values={
                 "name": name,
                 "matter": matter,
+                "title": title,
                 "legistar_event_item_id": legistar_event_item_id,
                 "created": datetime.utcnow()
             }

--- a/cdptools/databases/cloud_firestore_database.py
+++ b/cdptools/databases/cloud_firestore_database.py
@@ -716,6 +716,30 @@ class CloudFirestoreDatabase(Database):
             }
         )
 
+    def get_or_upload_event_topic(self, event_id: str, topic: str) -> Dict:
+        return self._get_or_upload_row(
+            table="event_topic",
+            pks=[("event_id", event_id), ("topic", topic)],
+            values={
+                "event_id": event_id,
+                "topic": topic,
+                "updated": datetime.utcnow()
+            }
+        )
+
+    def get_or_upload_event_entity(self, event_id: str, label: str, value: Any) -> Dict:
+        return self._get_or_upload_row(
+            table="event_topic",
+            pks=[("event_id", event_id), ("label", label), ("value", value)],
+            values={
+                "event_id": event_id,
+                "label": label,
+                "value": value,
+                "dtype": str(type(value)),
+                "updated": datetime.utcnow()
+            }
+        )
+
     def get_indexed_event_term(self, term: str, event_id: str) -> Dict:
         # Try find
         found = self._select_rows_with_max_results_expectation(

--- a/cdptools/databases/cloud_firestore_database.py
+++ b/cdptools/databases/cloud_firestore_database.py
@@ -735,7 +735,7 @@ class CloudFirestoreDatabase(Database):
                 "event_id": event_id,
                 "label": label,
                 "value": value,
-                "dtype": str(type(value)),
+                "dtype": self._determine_event_entity_dtype(value),
                 "updated": datetime.utcnow()
             }
         )

--- a/cdptools/databases/database.py
+++ b/cdptools/databases/database.py
@@ -317,7 +317,8 @@ class Database(ABC):
     def get_or_upload_minutes_item(
         self,
         name: str,
-        matter: Optional[str],
+        matter: Optional[str] = None,
+        title: Optional[str] = None,
         legistar_event_item_id: Optional[int] = None
     ) -> Dict:
         """
@@ -327,8 +328,10 @@ class Database(ABC):
         ---------
         name: str
             A name for the minutes item. Ex: "Appointment of Rene J. Peters, Jr."
-        matter: str
+        matter: Optional[str]
             A matter name for the minutes item. Ex: "Appt 01373"
+        title: Optional[str]
+            A human readable name for the minutes item. Ex: "A resolution regarding adoption of a Green New Deal."
         legistar_event_item_id: Optional[int]
             If the CDP instance is deployed for a city with Legistar, it is recommended to also store the `EventItemId`.
 

--- a/cdptools/databases/database.py
+++ b/cdptools/databases/database.py
@@ -705,6 +705,47 @@ class Database(ABC):
         return {}
 
     @abstractmethod
+    def get_or_upload_event_topic(self, event_id: str, topic: str) -> Dict:
+        """
+        Get or upload an event topic.
+
+        Parameters
+        ----------
+        event_id: str
+            The id for which event this topic is related to.
+        topic: str
+            The term or terms (as a string) that define the topic as a unique topic.
+
+        Returns
+        -------
+        details: Dict[str, Any]
+            A dictionary containing the data that was either uploaded or found.
+        """
+        return {}
+
+    @abstractmethod
+    def get_or_upload_event_entity(self, event_id: str, label: str, value: Any) -> Dict:
+        """
+        Get or upload an event entity. Because entities can be values that are other than strings, most databases,
+        should cast this to a string prior to storage. This is also why will store the data type (dtype).
+
+        Parameters
+        ----------
+        event_id: str
+            The id for which event this entity was referenced in.
+        label: str
+            The label for the entity. Ex: 'location', 'person', etc.
+        value: Any
+            The value for the entity. Ex: 'Bruce Harrell'.
+
+        Returns
+        -------
+        details: Dict[str, Any]
+            A dictionary containing the data that was either uploaded or found.
+        """
+        return {}
+
+    @abstractmethod
     def get_indexed_event_term(self, term: str, event_id: str) -> Dict:
         """
         Get a single indexed event term.

--- a/cdptools/databases/database.py
+++ b/cdptools/databases/database.py
@@ -71,6 +71,14 @@ class Match:
         return str(self)
 
 
+ENTITY_DTYPE_MAP = {
+    str: "STRING",
+    int: "INTEGER",
+    float: "DOUBLE",
+    datetime: "TIMESTAMP"
+}
+
+
 ###############################################################################
 
 
@@ -723,8 +731,29 @@ class Database(ABC):
         """
         return {}
 
+    @staticmethod
+    def _determine_event_entity_dtype(value: Union[str, int, float, datetime]) -> str:
+        """
+        To simplify the storage value of the dtype, instead of using specifically Python types, this simply returns a
+        string value for each of the allowed dtypes.
+
+        Parameters
+        ----------
+        value: Union[str, int, float, datetime]
+            The value to determine type for.
+
+        Returns
+        -------
+        dtype: str
+            The storage ready string to store as the data type of the value.
+        """
+        try:
+            return ENTITY_DTYPE_MAP[type(value)]
+        except KeyError:
+            return str(type(value))
+
     @abstractmethod
-    def get_or_upload_event_entity(self, event_id: str, label: str, value: Any) -> Dict:
+    def get_or_upload_event_entity(self, event_id: str, label: str, value: Union[str, int, float, datetime]) -> Dict:
         """
         Get or upload an event entity. Because entities can be values that are other than strings, most databases,
         should cast this to a string prior to storage. This is also why will store the data type (dtype).

--- a/cdptools/tests/databases/test_database.py
+++ b/cdptools/tests/databases/test_database.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
+
 import pandas as pd
 import pytest
 
@@ -69,3 +71,15 @@ def test_reshape_list_of_rows_to_dictionary(rows, table, expected):
 def test_reshape_list_of_rows_to_dataframe(rows, table, expected):
     actual = Database._reshape_list_of_rows_to_dataframe(rows, table)
     assert actual.equals(expected)
+
+
+@pytest.mark.parametrize("value, expected", [
+    (1, "INTEGER"),
+    (1.0, "DOUBLE"),
+    ("hello", "STRING"),
+    (datetime.utcnow(), "TIMESTAMP"),
+    ({"some", "weird", "object"}, "<class 'set'>")
+])
+def test_determine_event_entity_dtype(value, expected):
+    actual = Database._determine_event_entity_dtype(value)
+    assert actual == expected


### PR DESCRIPTION
In prep for both adding minutes item titles to each minutes item and the data from NLP outputs (entities and topics), the database schema needs to be updated to allow these items.