### PR TITLE
bugfix/add-update-legistar-data-pipeline

### DIFF
--- a/cdptools/databases/cloud_firestore_database.py
+++ b/cdptools/databases/cloud_firestore_database.py
@@ -466,18 +466,16 @@ class CloudFirestoreDatabase(Database):
 
     def get_or_upload_minutes_item(
         self,
-        name: str,
+        title: str,
         matter: Optional[str] = None,
-        title: Optional[str] = None,
         legistar_event_item_id: Optional[int] = None
     ) -> Dict:
         return self._get_or_upload_row(
             table="minutes_item",
-            pks=[("name", name)],
+            pks=[("title", title)],
             values={
-                "name": name,
-                "matter": matter,
                 "title": title,
+                "matter": matter,
                 "legistar_event_item_id": legistar_event_item_id,
                 "created": datetime.utcnow()
             }

--- a/cdptools/databases/database.py
+++ b/cdptools/databases/database.py
@@ -324,22 +324,19 @@ class Database(ABC):
     @abstractmethod
     def get_or_upload_minutes_item(
         self,
-        name: str,
+        title: str,
         matter: Optional[str] = None,
-        title: Optional[str] = None,
         legistar_event_item_id: Optional[int] = None
     ) -> Dict:
         """
-        Get or upload a minutes item. In Legistar this is commonly referred to as an event item.
+        Get or upload a minutes item. In Legistar this is commonly referred to as an event item (or "matter").
 
         Parameters
         ---------
-        name: str
-            A name for the minutes item. Ex: "Appointment of Rene J. Peters, Jr."
+        title: str
+            A title for the minutes item. Ex: "Appointment of Rene J. Peters, Jr."
         matter: Optional[str]
             A matter name for the minutes item. Ex: "Appt 01373"
-        title: Optional[str]
-            A human readable name for the minutes item. Ex: "A resolution regarding adoption of a Green New Deal."
         legistar_event_item_id: Optional[int]
             If the CDP instance is deployed for a city with Legistar, it is recommended to also store the `EventItemId`.
 

--- a/cdptools/dev_utils/check_system_version.py
+++ b/cdptools/dev_utils/check_system_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# import importlib
+import logging
+
+###############################################################################
+
+log = logging.getLogger(__name__)
+
+###############################################################################
+
+
+# def check_system_version(lower: str, target: str) -> bool:
+#     """
+#     Given two semantic versioning strings, check if
+#
+#     Parameters
+#     ----------
+#     module_path: Union[str, List[str]]
+#         Python module path or list of path parts to a custom module. Ex: "cptools.pipeline"
+#     object_name: str
+#         Name of the object to retrieve from the module. Ex: "Pipeline"
+#     object_kwargs: Dict
+#         Any kwargs to pass to the object.
+#
+#     Returns
+#     -------
+#     obj: object
+#         The initialized object.
+#     """
+#     # Convert module path to string
+#     if isinstance(module_path, list):
+#         module_path = ".".join(module_path)
+#
+#     # Load target module
+#     mod = importlib.import_module(module_path)
+#     obj = getattr(mod, object_name)
+#     obj = obj(**object_kwargs)
+#
+#     # Log
+#     log.debug(f"Using object: {type(obj)}")
+#
+#     return obj

--- a/cdptools/legistar_utils/events.py
+++ b/cdptools/legistar_utils/events.py
@@ -220,11 +220,11 @@ def parse_legistar_event_details(legistar_event_details: Dict, ignore_minutes_it
     # Parse event items
     minutes_items = []
     for legistar_event_item in legistar_event_details["EventItems"]:
-        # Choose name based off available data
-        if legistar_event_item["EventItemMatterName"]:
-            minutes_item_name = _clean_legistar_string_data(legistar_event_item["EventItemMatterName"])
+        # Choose title based off available data
+        if legistar_event_item["EventItemTitle"]:
+            minutes_item_title = _clean_legistar_string_data(legistar_event_item["EventItemTitle"])
         else:
-            minutes_item_name = _clean_legistar_string_data(legistar_event_item["EventItemTitle"])
+            minutes_item_title = _clean_legistar_string_data(legistar_event_item["EventItemMatterName"])
 
         # Choose matter name based off available data
         if legistar_event_item["EventItemMatterName"]:
@@ -233,7 +233,7 @@ def parse_legistar_event_details(legistar_event_details: Dict, ignore_minutes_it
             minutes_item_matter = _clean_legistar_string_data(legistar_event_item["EventItemMatterFile"])
 
         # Only continue if the minutes item name is not ignored
-        if minutes_item_name not in ignore_minutes_items:
+        if minutes_item_title not in ignore_minutes_items:
             # Sometimes this is missing...
             # Not sure why
             index = legistar_event_item["EventItemMinutesSequence"]
@@ -247,7 +247,7 @@ def parse_legistar_event_details(legistar_event_details: Dict, ignore_minutes_it
 
             # Construct minutes item
             minutes_item = {
-                "name": minutes_item_name,
+                "title": minutes_item_title,
                 "matter": minutes_item_matter,
                 "index": index,
                 "legistar_event_item_id": int(legistar_event_item["EventItemId"])

--- a/cdptools/pipelines/event_gather_pipeline.py
+++ b/cdptools/pipelines/event_gather_pipeline.py
@@ -220,7 +220,7 @@ class EventGatherPipeline(Pipeline):
             for m_item in event["minutes_items"]:
                 # Store or get minutes item
                 minutes_item_details = self.database.get_or_upload_minutes_item(
-                    name=m_item["name"],
+                    title=m_item["title"],
                     matter=m_item["matter"],
                     legistar_event_item_id=m_item["legistar_event_item_id"]
                 )

--- a/cdptools/tests/event_scrapers/test_seattle_event_scraper.py
+++ b/cdptools/tests/event_scrapers/test_seattle_event_scraper.py
@@ -64,25 +64,3 @@ m_d_sy = "{}/{}/{}".format(now.month, now.day, str(now.year)[2:])
 MOCK_EVENT_HTML = """<div class="row borderBottomNone paginationItem"><div class="col-xs-12 col-sm-4 col-md-3"><a href="/testing?videoid=x99999" onclick="javascript:loadJWPlayer7('http://video.seattle.gov:8080/media/council/tests_032919.mp4','/images/seattlechannel/videoimages/channelGeneric.jpg', &quot;&lt;p&gt;The City of Seattle conducts a hearing on testing Council Data Project parsers. &lt;/p&gt;&lt;p&gt;&lt;/p&gt;&quot;, 'Example Body on Tests', '{m_d_sy}', '1:31:24', '9021807', false,'x93428', '', '', '', '', '', '', '', '', ''); return false;" target=""><img alt="Example Body on Tests {m_d_sy}" class="img-responsive" src="images/seattlechannel/videoimages/channelGeneric.jpg" title="Example Body on Tests {m_d_sy}"/></a></div><div class="col-xs-12 col-sm-8 col-md-9"><div class="titleDateContainer"><h2 class="paginationTitle"><a href="/testing?videoid=x99999" onclick="javascript:loadJWPlayer7('http://video.seattle.gov:8080/media/council/tests_032919.mp4','images/seattlechannel/videoimages/channelGeneric.jpg', &quot;&lt;p&gt;The City of Seattle conducts a hearing on testing Council Data Project parsers. &lt;/p&gt;&lt;p&gt;&lt;/p&gt;&quot;, 'Example Body on Tests', '{m_d_sy}', '1:31:24', '9021807', false,'x93428', '', '', '', '', '', '', '', '', ''); return false;" title="Example Body on Tests {m_d_sy}">Example Body on Tests</a></h2><div class="videoDate">{m_d_y}</div></div><div class="titleExcerptText"><p>Agenda: Public Comment; CB 999999.</p><p></p></div></div></div>""".format(m_d_y=m_d_y, m_d_sy=m_d_sy)  # noqa: E501
 MOCK_EVENT_SOUP = BeautifulSoup(MOCK_EVENT_HTML, "html.parser")
 SIBLING_ROUTE = "http://www.seattlechannel.org/CityCouncil"
-
-
-# def test_parse_seattle_channel_event():
-#     event = SeattleEventScraper._parse_seattle_channel_event(MOCK_EVENT_SOUP, SIBLING_ROUTE)
-#
-#     assert event == MOCK_EVENT
-
-
-# @pytest.mark.parametrize("a, b, expected", [
-#     (["Hello", "World"], ["Hello", "World"], True),
-#     (["Hello", "Test", "World"], ["Hello", "World"], True),
-#     (["Hello", "World"], ["Hello", "Test", "World"], True),
-#     (["Hello"], ["World"], False),
-#     (["World", "Hello"], ["Hello", "World"], False),
-#     (["This", "Is", "A", "Test"], ["Hello", "Is", "A", "World"], False)
-# ])
-# def test_two_items_list_match(a, b, expected):
-#     assert expected == SeattleEventScraper._shared_items_in_list_exist_and_ordered(a, b)
-
-
-# TODO:
-# Create tests for mock requests to get routes

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,20 @@
+# Migrations
+
+Unfortunately because there is no [`alembic`](https://alembic.sqlalchemy.org/en/latest/) style system for migrations or
+backfills for any database type, the scripts contained in the `scripts` directory will have to be run one at a time
+from the point the CDP instance is at to the desired version. These migrations will follow a stripped down version of
+`alembic`.
+
+Each migration script will follow the naming convention:
+
+    {version_a}-{version_b}_{short-description}
+
+Where `version_a` and `version_b` are two versions you want to go up or down from one another.
+
+So if trying to upgrade a CDP instance from 2.0.2 to 2.0.3, you would look for `2.0.2-2.0.3_hello-world...` for example.
+
+Migrations may not be needed for every minor or patch version of CDP, so there may be a `2.0.2` and a `2.0.4` but no
+`2.0.3` for example. In this case just run to the matching migration: `2.0.2-2.0.4_hello-world...`.
+
+Every migration will have a `downgrade` and an `upgrade` function, the default will be to upgrade, you can specify which
+one with a parameter (`--down` or `--up`).

--- a/migrations/scripts/2.0.0-2.0.4_add-core-nlp-additions.py
+++ b/migrations/scripts/2.0.0-2.0.4_add-core-nlp-additions.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import argparse
+import logging
+import sys
+import traceback
+from pathlib import Path
+
+from cdptools import get_module_version
+from cdptools.dev_utils import check_system_version, load_custom_object
+
+###############################################################################
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(levelname)4s: %(module)s:%(lineno)4s %(asctime)s] %(message)s"
+)
+log = logging.getLogger(__name__)
+
+###############################################################################
+
+LOWER_VERSION = "2.0.0"
+UPPER_VERSION = "2.0.4"
+
+###############################################################################
+
+
+class Args(argparse.Namespace):
+
+    def __init__(self):
+        self.__parse()
+
+    def __parse(self):
+        p = argparse.ArgumentParser(
+            prog="cdp_migrate_2.0.0_2.0.4",
+            description="Add core NLP additions."
+        )
+        p.add_argument("--up", "--upgrade", action="store_true", dest="upgrade", default=True,
+                       help="Should the system upgrade or downgrade versions. Defaults to upgrade.")
+        p.add_argument("--down", "--downgrade", action="store_false", dest="upgrade", default=True,
+                       help="Should the system upgrade or downgrade versions. Defaults to upgrade.")
+        p.add_argument("config_path", type=Path,
+                       help="Path to a configuration file with details for the migration script.")
+        p.add_argument("--debug", action="store_true", dest="debug", help="Show traceback if the script were to fail.")
+        p.parse_args(namespace=self)
+
+
+###############################################################################
+
+def upgrade(config_path: Path):
+    log.info(f"Upgrading from {LOWER_VERSION} to {UPPER_VERSION}")
+
+
+def downgrade(config_path: Path):
+    log.info(f"Downgrading from {UPPER_VERSION} to {LOWER_VERSION}")
+
+
+def run(args: Args):
+    try:
+        log.info(f"CDPTools Version: {get_module_version()}")
+        log.info(f"Initializing: {args.pipeline_type}")
+
+        # Run upgrade/ downgrade
+        if args.upgrade:
+            upgrade(args.config_path)
+        else:
+            downgrade(args.config_path)
+
+    except Exception as e:
+        log.error("=============================================")
+        if args.debug:
+            log.error("\n\n" + traceback.format_exc())
+            log.error("=============================================")
+        log.error("\n\n" + str(e) + "\n")
+        log.error("=============================================")
+        sys.exit(1)
+
+
+def main():
+    args = Args()
+    run(args)
+
+
+###############################################################################
+# Allow caller to directly run this module (usually in development scenarios)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This changes the database schema for minutes items from `name` to `title`. As a part of that the `SeattleEventScraper` (`legistar_utils.events.parse_legistar_event_details`) now chooses the `EventItemTitle` over the `EventItemMatterName`.

A new pipeline is available to update events in the database as new Legistar data becomes available.

A backfill / migration script is also available to change the column names on the `minutes_item` table.