### PR TITLE
bugfix/workflows-and-docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:
-        user: {{ cookiecutter.pypi_username }}
+        user: councildataproject
         password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ this package are objects to do just that; connect and request data from CDP inst
 ## User Features
 * Plain text query for events or minutes items
 
-* [Database schema](docs/resources/database_diagram.pdf) allows for simple querying of:
+* [Database schema](https://councildataproject.github.io/cdptools/_images/database_diagram.png) allows for simple querying of:
     * events (meetings)
     * voting history of a city council or city council member
     * bodies (committees)


### PR DESCRIPTION
Fixes the image reference in the README to point to the docs hosted database schema png and updates the publish workflow file to use the actual pypi username instead of the cookiecutter slug.
