### PR TITLE
bugfix/parameterize-vtt-confidence

### DIFF
--- a/configs/seattle-event-gather-pipeline.json
+++ b/configs/seattle-event-gather-pipeline.json
@@ -40,7 +40,8 @@
             "module_path": "cdptools.sr_models.webvtt_sr_model",
             "object_name": "WebVTTSRModel",
             "object_kwargs": {
-                "new_turn_pattern": "&gt;"
+                "new_turn_pattern": "&gt;",
+                "confidence": 0.97
             }
         },
         "catch": {


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
I am working on #95, which in turn is just the upstream task for #79. During working I realized that WebVTT model results for at least Seattle aren't actually 100% accurate / "confident". Because of this I think the "best" way to mutate this is to allow the model to be initialized with a confidence parameter. This isn't the best but I think for now it is allowable.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
