### PR TITLE
Body and file schema

### DIFF
--- a/database_schema.md
+++ b/database_schema.md
@@ -81,7 +81,8 @@ body_id: {
     name: str
     description: str
     created: datetime
-    ended: datetime
+    start_date: datetime
+    end_date: datetime
     is_active: bool
     chair_person_id: str
     external_source_id: str

--- a/database_schema.md
+++ b/database_schema.md
@@ -82,9 +82,10 @@ body_id: {
     description: str
     created: datetime
     ended: datetime
+    is_active: bool
     chair_person_id: str
     external_source_id: str
-    is_select: bool
+    tag: str
 }
 ```
 

--- a/database_schema.md
+++ b/database_schema.md
@@ -75,6 +75,29 @@ person_id: {
 }
 ```
 
+### Body
+```
+body_id: {
+    name: str
+    description: str
+    created: datetime
+    ended: datetime
+    chair_person_id: str
+    external_source_id: str
+    is_select: bool
+}
+```
+
+### File
+```
+file_id: {
+    uri: str
+    filename: str
+    description: str
+    content_type: str
+    created: datetime
+}
+```
 
 ### Role
 A role is a person's job for a period of time in the city council.
@@ -108,3 +131,7 @@ A table to coordinate file details between a database and file store.
 Any supporting document for a specific events minutes item. Previously this was on the Minutes Item relationship but
 that was incorrect as when querying for every level data, all minutes item documents would be returned regardless of
 meeting. Example: an event showing all "future" amendments to a matter.
+
+### Body
+A body, also known as committee, is a subset of city council members that stands for a certain topic/purpose.
+An example would be the Seattle "Governance and Education" committee which consists of 6 of the 9 city council members.


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Provide context of changes.
* I didn't really see anything about `file` that should be different from the existing schema.
* For body, I added `external_source_id`, `ended`, `chair_person_id`, and `is_select`. I thought including the chair would be useful for quickly finding the active chair for a given body. 
* I also thought adding a flag for whether a body is select or not wouldn't hurt, since it doesn't add any complexity but could be a useful bit of info. 
