### PR TITLE
admin/add-role-and-seat-collection

### DIFF
--- a/database_schema.md
+++ b/database_schema.md
@@ -83,6 +83,19 @@ For example: a person has two terms as city council member for D4 then a term as
 Roles can also be tied to committee chairs.
 For example: a council member spends a term on the transportation committee and then spends a term on the finance
 committee.
+```
+role_id: {
+    person_id: str
+    title: str
+    body_id: str
+    body_name: str
+    start_date: datetime
+    end_date: datetime
+    seat_id: str
+    external_source_id: int
+    created: datetime
+}
+```
 
 ### Matter
 A matter is specifically a legislative matter. A bill, resolution, initiative, etc. It has a sponser which may be a

--- a/database_schema.md
+++ b/database_schema.md
@@ -103,7 +103,7 @@ A seat is an electable office on the City Council.
 seat_id: {
     name: str
     electoral_area: str
-    type: str
+    electoral_type: str
     map_file_id: str
     map_uri: str
     created: datetime

--- a/database_schema.md
+++ b/database_schema.md
@@ -62,13 +62,13 @@ person_id: {
     picture_uri: str
     is_active: bool
     is_council_president: bool
-    most_recent_district_id: str
-    most_recent_district_name: str
-    most_recent_district_map_file_id: str
-    most_recent_district_map_uri: str
+    most_recent_seat_id: str
+    most_recent_seat_name: str
+    most_recent_seat_map_file_id: str
+    most_recent_seat_map_uri: str
     most_recent_chair_body_id: str
     most_recent_chair_body_name: str
-    terms_serving_in_current_district_role: int
+    terms_serving_in_current_seat_role: int
     terms_serving_in_current_committee_chair_role: int
     external_source_id: int
     created: datetime

--- a/database_schema.md
+++ b/database_schema.md
@@ -64,6 +64,7 @@ person_id: {
     is_council_president: bool
     most_recent_seat_id: str
     most_recent_seat_name: str
+    most_recent_seat_electoral_area: str
     most_recent_seat_map_file_id: str
     most_recent_seat_map_uri: str
     most_recent_chair_body_id: str

--- a/database_schema.md
+++ b/database_schema.md
@@ -86,6 +86,7 @@ committee.
 ```
 role_id: {
     person_id: str
+    person_name: str
     title: str
     body_id: str
     body_name: str

--- a/database_schema.md
+++ b/database_schema.md
@@ -97,6 +97,19 @@ role_id: {
 }
 ```
 
+### Seat
+A seat is an electable office on the City Council.
+```
+seat_id: {
+    name: str
+    electoral_area: str
+    type: str
+    map_file_id: str
+    map_uri: str
+    created: datetime
+}
+```
+
 ### Matter
 A matter is specifically a legislative matter. A bill, resolution, initiative, etc. It has a sponser which may be a
 person or a body.


### PR DESCRIPTION
**Role and Seat collections proposal**
For Role:
`title` can be Council Member, Council President, Chair, Vice Chair, Member, Alternate

For Seat:
`name` can be Position 1-9
`electoral_area` can be District 1-7, or Citywide
`electoral_type` can be district or at-large

Example of what it could look like:  [example](https://gist.github.com/tohuynh/266ab8d298d77e95b23fef42f60a055a), without the `created` field.
The example specifically models Person 1 as being a Council Member for District 1, Council President, Chair of Housing Committee, Vice Chair of Transporation Committee.

Person 2 is a Council Member for Position 9, one of the Citywide seats.

**Front end query requirements:**
With these designs, we could display all the current roles of a person on the person details' page.
If we wanted to, we could also display all relevant persons for a body.

Also I changed the district str in Person collection to seat
