### PR TITLE
bugfix/firebase-rejects-long-strings

### DIFF
--- a/cdptools/legistar_utils/events.py
+++ b/cdptools/legistar_utils/events.py
@@ -247,6 +247,10 @@ def parse_legistar_event_details(legistar_event_details: Dict, ignore_minutes_it
             else:
                 index = -1
 
+            # Firebase doesn't like long strings?
+            if len(minutes_item_name) > 800:
+                minutes_item_name = f"{minutes_item_name[:800]}..."
+
             # Construct minutes item
             minutes_item = {
                 "name": minutes_item_name,


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

The website was having difficulty loading an event because the transcript reference wasn't stored in cloud firestore. On inspection of the server log:
```
[INFO: event_gather_pipeline: 338 2020-02-19 22:37:14,059] Skipping event: 2099d43d8ef915312b0a171b3e9729f8149450538448e6fde0d48df76e5b1d63 (b5256dfa-359a-4504-9930-d4f6cbaedd9d)
[INFO: event_gather_pipeline: 364 2020-02-19 22:37:14,059] Completed event: 2099d43d8ef915312b0a171b3e9729f8149450538448e6fde0d48df76e5b1d63 (https://video.seattle.gov/media/council/brief_021820_2012013V.mp4)
[INFO: event_gather_pipeline: 338 2020-02-19 22:37:14,237] Skipping event: e53660ab9fd74830a11547b710dcfdca5916867385a1d8841dfdc89fefe6d75d (9cd50a0a-6b80-441b-ada0-916cbc19bdf5)
[INFO: event_gather_pipeline: 364 2020-02-19 22:37:14,237] Completed event: e53660ab9fd74830a11547b710dcfdca5916867385a1d8841dfdc89fefe6d75d (https://video.seattle.gov/media/council/council_021820_2022013V.mp4)
[INFO: event_gather_pipeline: 338 2020-02-19 22:37:14,238] Skipping event: 888eaf1d31bf06ba1fe931ba336a685b45824469c77f3c2fcc6ac8771aee4b3f (481b7e57-c2e5-4027-a50d-c5414fa1b1ee)
[INFO: event_gather_pipeline: 364 2020-02-19 22:37:14,238] Completed event: 888eaf1d31bf06ba1fe931ba336a685b45824469c77f3c2fcc6ac8771aee4b3f (https://video.seattle.gov/media/council/land_021220_2632003V.mp4)
[INFO: event_gather_pipeline: 340 2020-02-19 22:37:14,286] Processing event: 6ebca9edb62aee75358417ab5b62ad9f18db7ea1766856d667a14563a905c357 (https://video.seattle.gov/media/council/tran_021920_2672005V.mp4)
[INFO: event_gather_pipeline: 338 2020-02-19 22:37:14,288] Skipping event: 180000b3f4508162734ba430ae167c60893f682ba57042a619f6dab58179efa1 (e29b7409-13fe-4fff-94e1-7a074f4dd8b1)
[INFO: event_gather_pipeline: 364 2020-02-19 22:37:14,288] Completed event: 180000b3f4508162734ba430ae167c60893f682ba57042a619f6dab58179efa1 (https://video.seattle.gov/media/council/spec_LID_9022004V.mp4)
[INFO: webvtt_sr_model: 172 2020-02-19 22:37:18,725] Completed transcription for: https://seattlechannel.org/documents/seattlechannel/closedcaption/2020/tran_021920_2672005.vtt. Confidence: 0.97
[INFO: gcs_file_store: 138 2020-02-19 22:37:19,044] Stored file: gs://cdp-seattle.appspot.com/6ebca9edb62aee75358417ab5b62ad9f18db7ea1766856d667a14563a905c357_raw_transcript_0.json
[INFO: gcs_file_store: 138 2020-02-19 22:37:19,660] Stored file: gs://cdp-seattle.appspot.com/6ebca9edb62aee75358417ab5b62ad9f18db7ea1766856d667a14563a905c357_ts_sentences_transcript_0.json
[INFO: gcs_file_store: 138 2020-02-19 22:37:20,284] Stored file: gs://cdp-seattle.appspot.com/6ebca9edb62aee75358417ab5b62ad9f18db7ea1766856d667a14563a905c357_ts_speaker_turns_transcript_0.json
[INFO: gcs_file_store: 138 2020-02-19 22:37:29,280] Stored file: gs://cdp-seattle.appspot.com/exception_log_6a157298-6b44-4e26-9440-7b3b7725148d.err
[INFO: gcs_file_store: 138 2020-02-19 22:37:30,904] Stored file: gs://cdp-seattle.appspot.com/exception_log_39d9fa27-80c4-4a72-9295-e849d1bc5e92.err
[INFO: event_gather_pipeline: 383 2020-02-19 22:37:32,477] Completed event processing.
[INFO: event_gather_pipeline: 384 2020-02-19 22:37:32,477] ================================================================================
```

We can see that an error occurred between the storage of the transcript file and the event upload.

Downloading and viewing the exception log we get back the following:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/google/api_core/grpc_helpers.py", line 79, in next
    return six.next(self._wrapped)
  File "/usr/local/lib/python3.7/dist-packages/grpc/_channel.py", line 416, in __next__
    return self._next()
  File "/usr/local/lib/python3.7/dist-packages/grpc/_channel.py", line 706, in _next
    raise self
grpc._channel._MultiThreadedRendezvous: <_MultiThreadedRendezvous of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "value for name is too large to be used in a query"
	debug_error_string = "{"created":"@1582151848.989089267","description":"Error received from peer ipv4:216.58.193.74:443","file":"src/core/lib/surface/call.cc","file_line":1056,"grpc_message":"value for name is too large to be used in a query","grpc_status":3}"
>
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/cdptools/cdptools/pipelines/event_gather_pipeline.py", line 276, in task_parse_and_upload_constructed_event
    legistar_event_item_id=m_item["legistar_event_item_id"]
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 506, in get_or_upload_minutes_item
    "created": datetime.utcnow()
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 461, in _get_or_upload_row
    expected_max_rows=1
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 442, in _select_rows_with_max_results_expectation
    matching = self.select_rows_as_list(table=table, filters=pks)
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 355, in select_rows_as_list
    return self._select_rows_as_list_with_creds(table=table, filters=filters, order_by=order_by, limit=limit)
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 210, in _select_rows_as_list_with_creds
    return [{f"{table}_id": i.id, **i.to_dict()} for i in ref.stream()]
  File "/home/cdptools/cdptools/databases/cloud_firestore_database.py", line 210, in <listcomp>
    return [{f"{table}_id": i.id, **i.to_dict()} for i in ref.stream()]
  File "/usr/local/lib/python3.7/dist-packages/google/cloud/firestore_v1/query.py", line 775, in stream
    for response in response_iterator:
  File "/usr/local/lib/python3.7/dist-packages/google/api_core/grpc_helpers.py", line 81, in next
    six.raise_from(exceptions.from_grpc_error(exc), exc)
  File "<string>", line 3, in raise_from
google.api_core.exceptions.InvalidArgument: 400 value for name is too large to be used in a query
```

This indicates two things:
1. The error occurred during the upload of the `get_or_upload_minutes_item`
2. After several minutes trying to figure out _which_ key was being rejected, we realized that the error string was informing us just poorly in my opinion. The key that was rejected for size was `name`. (400 value for _name_ is too large...)

After @tohuynh tracked down the corresponding legistar event ([here](http://seattle.legistar.com/MeetingDetail.aspx?ID=763685&GUID=5A4B6B74-337C-4EBB-80A4-2DED2A665A11&Options=info&Search=)) we can see that the "Title" of "CB 119744" is rather long and that was likely the issue.

After clearing the database of all references to the broken event and rerunning with this code, the new event is live. [Here](https://councildataproject.github.io/seattle/#/events/5377ac9a-16ac-4850-8982-e3c7f4d4b4fe)

I don't think this is the _best_ fix, but it is _a_ fix.

I would argue that because we have a link to the full text of the matter it doesn't matter that our database has shortened matter names, but from a query standpoint I can also argue that we are mutating the matter data which I don't really like.

- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
