### PR TITLE
feature/add-matter-schema

### DIFF
--- a/database_schema.md
+++ b/database_schema.md
@@ -137,8 +137,34 @@ seat_id: {
 ```
 
 ### Matter
-A matter is specifically a legislative matter. A bill, resolution, initiative, etc. It has a sponser which may be a
-person or a body.
+A matter is specifically a legislative matter. A bill, resolution, initiative, etc.
+```
+matter_id: {
+    name: str
+    matter_type_id: str
+    title: str
+    status: str
+    agenda_date: datetime
+    keywords: [
+        {
+            id: str
+            phrase: str
+        }
+    ]
+    external_source_id: int
+    updated: datetime
+}
+```
+
+### Matter Type
+A matter type can be Council Bill, Resolution, Appointment, etc.
+```
+matter_type_id: {
+    name: str
+    external_source_id: int
+    created: datetime
+}
+```
 
 ### Minutes Item
 A minutes item is anything found on the agenda / minutes.

--- a/database_schema.md
+++ b/database_schema.md
@@ -153,6 +153,7 @@ matter_id: {
     ]
     external_source_id: int
     updated: datetime
+    created: datetime
 }
 ```
 

--- a/database_schema.md
+++ b/database_schema.md
@@ -149,6 +149,11 @@ matter_id: {
         body: str
         datetime: datetime
     }
+    next_event : {
+        id: str
+        body: str
+        datetime: datetime
+    }
     keywords: [
         {
             id: str

--- a/database_schema.md
+++ b/database_schema.md
@@ -144,7 +144,11 @@ matter_id: {
     matter_type_id: str
     title: str
     status: str
-    agenda_date: datetime
+    most_recent_event: {
+        id: str
+        body: str
+        datetime: datetime
+    }
     keywords: [
         {
             id: str


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
Add matter schema.
As I understand it, the `matter` collection is meant to be used to display the legislation cards and allow for [filtering.](https://docs.google.com/spreadsheets/d/1b_yOuBS-d1ckw5w_rRwpQvxcRfQoKM0aw8SGfMFIbN4/edit#gid=0)

For `mattter` collection:
`name` is the name of the matter. It has the form `{shortened_matter_type_name} {number}`. e.g. CB 119726.

`title` is a brief description of the matter.

`status` is the current status of the matter. On Legistar, there are 21 matter statuses, but I think we should narrow it down to 3: Adopted, Rejected, In Progress.

`agenda_date` is the date of the most recent event for which the matter is on the agenda.

`keywords` is a list of phrases pulled from `indexed_matter_term`.

I decided to use `updated` instead of `created`, because `status` and `agenda_date` will get updated over time.

For `matter_type` collection:
In order to allow for filtering matters by matter types, I needed to create the `matter_type` collection. This is for displaying the list checkboxes of matter types to allow users to select the different matter types. There are 11 matter types on Legistar. The list of matter types rarely ever changes. So I'm OK with adding this collection.
`name` is the matter type name. e.g. Council Bill (CB), Appointment (Appt), Resolution (Res)

The alternative to hardcode the list of matter types somewhere in the front end and change `matter_type_id` in `matter` collection to just `type_name`.


- [ ] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
