### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/cdptools/event_scrapers/seattle_event_scraper.py
+++ b/cdptools/event_scrapers/seattle_event_scraper.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 
 import requests
 from bs4 import BeautifulSoup
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from ..legistar_utils import events as legistar_event_tools
 from . import exceptions

--- a/cdptools/legistar_utils/events.py
+++ b/cdptools/legistar_utils/events.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from typing import Dict, List, Union
 
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 ###############################################################################
 
@@ -134,7 +134,7 @@ def get_matching_legistar_event_by_minutes_match(
     for the list provided. An example of this function being used may be found in SeattleEventScraper, but as a general
     use case, this will be used when a city has two separate systems for storing video and storing legistar data and
     you need to match up the video data with the legistar data. Event matching is determined by minutes item text set
-    difference. For details, on that algorithm, look at `fuzzywuzzy.fuzz.token_set_ratio`.
+    difference. For details, on that algorithm, look at `rapidfuzz.fuzz.token_set_ratio`.
 
     Parameters
     ----------

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,9 @@ interactive_requirements = [
 requirements = [
     "beautifulsoup4==4.8.0",
     "ffmpeg-python==0.2.0",
-    "fuzzywuzzy==0.17.0",
+    "rapidfuzz==0.2.1",
     "nltk==3.4.5",
     "pandas==0.25.0",
-    "python-Levenshtein==0.12.0",
     "requests[security]==2.22.0",
     "schedule==0.6.0",
     "setuptools>=44.0.0",


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.