### PR TITLE
admin/remove-py36-support

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,18 +11,18 @@ RUN apt-get install -y \
 # Add additional apt repository
 RUN add-apt-repository universe
 
-# Get python3.7 and pip
+# Get python3.8 and pip
 RUN apt-get update && apt-get install -y \
-    python3.7 \
-    python3.7-dev \
+    python3.8 \
+    python3.8dev \
     python3-pip \
     ffmpeg \
     git
 
-# Upgrade pip and force it to use python3.7
-RUN python3.7 -m pip install --upgrade pip
+# Upgrade pip and force it to use python3.8
+RUN python3.8 -m pip install --upgrade pip
 
-# Set python3.7 to default python
+# Set python3.8 to default python
 RUN ln -sf /usr/bin/python3.7 /usr/bin/python
 RUN ln -sf /usr/bin/python3.7 /usr/bin/python3
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ extra_requirements = {
 }
 
 setup(
-    author="Jackson Maxfield Brown, Nicholas Weber",
+    author="Jackson Maxfield Brown, To Huynh, Isaac Na, Nicholas Weber",
     author_email="jmaxfieldbrown@gmail.com, nmweber@uw.edu",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -88,8 +88,8 @@ setup(
         "Intended Audience :: Science/Research",
         "License :: OSI Approved :: BSD License",
         "Natural Language :: English",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Utilities"
     ],
     description="Tools to interact with and deploy CouncilDataProject instances",
@@ -108,6 +108,7 @@ setup(
     include_package_data=True,
     name="cdptools",
     packages=find_packages(exclude=["tests", "*.tests", "*.tests.*"]),
+    python_requires=">=3.7",
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py36, py37, py38, lint
+envlist = py37, py38, lint
 
 [testenv:lint]
 deps =


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.

`numpy` is dropping support for 3.6 next week. Yes, we _could_ pin to a specific version of `numpy` but I would rather just force the upgrade. I generally trust their support / drop schedule.

- [x] Provide relevant tests for your feature or bug fix.
- [x] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
