### PR TITLE
feature/firestore-update-field-in-collection

### DIFF
--- a/cdptools/databases/cloud_firestore_document_database.py
+++ b/cdptools/databases/cloud_firestore_document_database.py
@@ -810,6 +810,12 @@ class CloudFirestoreDocumentDatabase(DocumentStoreDatabase):
             },
         )
 
+    def update_collection_with_field(
+        self, collection: str, document_id: str, field: str, value: any,
+    ) -> Dict:
+        document = self._root.collection(collection).document(document_id)
+        document.update({field: value})
+
     def drop_collection(self, table, batch_size):
         docs = self._root.collection(table).list_documents(batch_size)
 

--- a/cdptools/databases/document_store_database.py
+++ b/cdptools/databases/document_store_database.py
@@ -826,6 +826,30 @@ class DocumentStoreDatabase(ABC):
         return {}
 
     @abstractmethod
+    def update_collection_with_field(
+        self, field: str, value: Any, collection: str, document_id: str,
+    ) -> None:
+        """
+        Update the field of a collection.
+
+        Parameters
+        ----------
+        field: str
+            The name of the field to be updated.
+        value: Any
+            The value of the field to be updated.
+        collection: str,
+            The name of the collection to be updated.
+        document_id: str
+            The document_id of the document to be updated. 
+
+        Returns
+        -------
+        None
+        """
+        return
+
+    @abstractmethod
     def drop_collection(self, collection: str):
         """
         Wipe the input collection.


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
 - Added a function that updates the field of a collection. This is to account for scenarios in our database where the values of a collection's hasn't actually been created yet.
- I thought it would be better to write one generalizable function then several specific function such as `add_minutes_item_to_event_minutes_item`. Either way we can just use `update_collection_with_field` or create collection-specific methods that use it.
- [x] Provide relevant tests for your feature or bug fix.
 - Just did a manual test, and it works for both simple and complex data structures (strings, dictionaries)
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
